### PR TITLE
Hiding Remove-DataRow button on SearchOutput

### DIFF
--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   data: Data[]
   server: string | null
   meta_name: string
+  showRemoveButton?: boolean
 }>()
 
 const emit = defineEmits(['remove'])
@@ -132,7 +133,7 @@ function handleRemove() {
         <template v-else> No data available. </template>
       </v-container>
     </td>
-    <td style="width: 1em; text-align: center;">
+    <td v-if="showRemoveButton !== false" style="width: 1em; text-align: center;">
       <v-btn
         icon
         size="x-small"

--- a/dashboard/src/components/DetailView.vue
+++ b/dashboard/src/components/DetailView.vue
@@ -321,6 +321,7 @@ function sortOutputs(key: string) {
               :data="items"
               :server="selectedServer"
               :meta_name="name"
+              :showRemoveButton="true"
               @remove="removeSelectedRow"
             >
             </DataRow>

--- a/dashboard/src/components/SearchOutput.vue
+++ b/dashboard/src/components/SearchOutput.vue
@@ -419,7 +419,8 @@ function getMetadata(item: any) : any[] {
                   :index="index"
                   :data="getMetadata(item)"
                   :server="selectedServer"        
-                  :meta_name="field.element"          
+                  :meta_name="field.element"
+                  :showRemoveButton="false"
                 >
                 </DataRow>
               </tbody>


### PR DESCRIPTION
- Hiding `Remove-DataRow` button from SearchOutput page