### PR TITLE
Use dd version (metadata) when retrieving data

### DIFF
--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -56,9 +56,10 @@ function toDataPath(metaName: string): string {
 }
 
 function getMetadataDdVersion(): string {
-  const version = props.data.find((item) => item.element === 'metadata_dd_version')?.value
-  const trimmedVersion = typeof version === 'string' ? version.trim() : '4.1.0'
-  return trimmedVersion || '4.1.0'
+  const version = props.data.find(
+    (item) => item.element === 'metadata_dd_version'
+  )?.value as string | undefined
+  return version === undefined ? '4.1.0' : version
 }
 
 async function fetchData() {

--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -57,7 +57,10 @@ function toDataPath(metaName: string): string {
 
 function getMetadataDdVersion(): string {
   const version = props.data.find((item) => item.element === 'metadata_dd_version')?.value
-  return typeof version === 'string' && version.trim() ? version.trim() : '4.1.0'
+  if (typeof version !== 'string') return '4.1.0'
+
+  const trimmedVersion = version.trim()
+  return trimmedVersion || '4.1.0'
 }
 
 async function fetchData() {
@@ -73,7 +76,7 @@ async function fetchData() {
   fetchedValue.value = null
   try {
     const ddVersion = encodeURIComponent(getMetadataDdVersion())
-    const url = `${props.server}/v${config.data_api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=${ddVersion}`
+    const url = `${props.server}/v${config.api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=${ddVersion}`
     const resp = await fetch(url, { signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`)
     fetchedValue.value = await resp.json()

--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -73,7 +73,7 @@ async function fetchData() {
   fetchedValue.value = null
   try {
     const ddVersion = encodeURIComponent(getMetadataDdVersion())
-    const url = `${props.server}/v${config.api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=${ddVersion}`
+    const url = `${props.server}/v${config.data_api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=${ddVersion}`
     const resp = await fetch(url, { signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`)
     fetchedValue.value = await resp.json()

--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -55,6 +55,11 @@ function toDataPath(metaName: string): string {
   return 'summary/' + name.replace(/\./g, '/')
 }
 
+function getMetadataDdVersion(): string {
+  const version = props.data.find((item) => item.element === 'metadata_dd_version')?.value
+  return typeof version === 'string' && version.trim() ? version.trim() : '4.1.0'
+}
+
 async function fetchData() {
   if (!props.simId || !props.server) return
 
@@ -67,7 +72,8 @@ async function fetchData() {
   fetchError.value = null
   fetchedValue.value = null
   try {
-    const url = `${props.server}/v${config.api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=4.1.1`
+    const ddVersion = encodeURIComponent(getMetadataDdVersion())
+    const url = `${props.server}/v${config.api_version}/simulation/${props.simId}/data?path=${encodeURIComponent(toDataPath(props.meta_name))}&dd_version=${ddVersion}`
     const resp = await fetch(url, { signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`)
     fetchedValue.value = await resp.json()

--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -57,7 +57,7 @@ function toDataPath(metaName: string): string {
 
 function getMetadataDdVersion(): string {
   const version = props.data.find((item) => item.element === 'metadata_dd_version')?.value
-  const trimmedVersion = typeof version === 'string' ? version.trim() : ''
+  const trimmedVersion = typeof version === 'string' ? version.trim() : '4.1.0'
   return trimmedVersion || '4.1.0'
 }
 

--- a/dashboard/src/components/DataRow.vue
+++ b/dashboard/src/components/DataRow.vue
@@ -57,9 +57,7 @@ function toDataPath(metaName: string): string {
 
 function getMetadataDdVersion(): string {
   const version = props.data.find((item) => item.element === 'metadata_dd_version')?.value
-  if (typeof version !== 'string') return '4.1.0'
-
-  const trimmedVersion = version.trim()
+  const trimmedVersion = typeof version === 'string' ? version.trim() : ''
   return trimmedVersion || '4.1.0'
 }
 

--- a/dashboard/src/config.ts
+++ b/dashboard/src/config.ts
@@ -33,8 +33,7 @@ const serverConfig = runtimeConfig.serverConfig
 const defaultServer = runtimeConfig.defaultServer
 
 const config: Readonly<{ [key: string]: any }> = {
-  api_version: '1.2',
-  data_api_version: '1.3',
+  api_version: '1.3',
   servers,
   serverConfig,
   defaultServer,

--- a/dashboard/src/config.ts
+++ b/dashboard/src/config.ts
@@ -34,6 +34,7 @@ const defaultServer = runtimeConfig.defaultServer
 
 const config: Readonly<{ [key: string]: any }> = {
   api_version: '1.2',
+  data_api_version: '1.3',
   servers,
   serverConfig,
   defaultServer,


### PR DESCRIPTION
Use the simulation’s metadata_dd_version when requesting IMAS data. If metadata_dd_version is not available, the dashboard falls back to 4.1.0. 

Related PR in SimDB --
https://github.com/iterorganization/SimDB/pull/106 